### PR TITLE
Fix version mapping when customing the GA version

### DIFF
--- a/spring-reference.yaml
+++ b/spring-reference.yaml
@@ -202,7 +202,6 @@
     - artifactId: spring-cloud-azure-starter-data-cosmos
       groupId: com.azure.spring
       versionGA: 4.4.1
-      versionPreview: 6.0.0-beta.3
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring Data Azure Cosmos DB, which enables developers to easily integrate with Azure Cosmos
@@ -1018,21 +1017,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-jdbc-mysql
       groupId: com.azure.spring
-      versionGA: 4.4.1
+      versionGA: 4.5.0-beta.1
       versionPreview: 6.0.0-beta.3
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Database for MySQL.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_4.4.1/sdk/spring/spring-cloud-azure-starter-jdbc-mysql
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_4.5.0-beta.1/sdk/spring/spring-cloud-azure-starter-jdbc-mysql
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-jdbc-mysql
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.4.1/mysql/spring-cloud-azure-starter-jdbc-mysql/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.5.0-beta.1/mysql/spring-cloud-azure-starter-jdbc-mysql/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,2.7.3]"
+        compatibilityRange: "[2.5.0,3.0.0-RC1]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.14]"
           groupId: com.azure.spring
@@ -1061,21 +1060,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-jdbc-postgresql
       groupId: com.azure.spring
-      versionGA: 4.4.1
+      versionGA: 4.5.0-beta.1
       versionPreview: 6.0.0-beta.3
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Database for PostgreSQL.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_4.4.1/sdk/spring/spring-cloud-azure-starter-jdbc-postgresql
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_4.5.0-beta.1/sdk/spring/spring-cloud-azure-starter-jdbc-postgresql
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-jdbc-postgresql
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.4.1/postgresql/spring-cloud-azure-starter-jdbc-postgresql/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.5.0-beta.1/postgresql/spring-cloud-azure-starter-jdbc-postgresql/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,2.7.3]"
+        compatibilityRange: "[2.5.0,3.0.0-RC1]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.14]"
           groupId: com.azure.spring

--- a/src/main/java/com/azure/spring/reference/intellij/SpringReferenceIntellijApplication.java
+++ b/src/main/java/com/azure/spring/reference/intellij/SpringReferenceIntellijApplication.java
@@ -31,6 +31,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -233,7 +234,10 @@ public class SpringReferenceIntellijApplication implements CommandLineRunner {
     private VersionSpec findVersion(SpringArtifactSpec springArtifactSpec) {
         VersionSpec bomVersion = this.versionSpecMap.get(springArtifactSpec.getBomArtifact());
         VersionSpec artifactVersion = this.versionSpecMap.get(springArtifactSpec.getArtifactId());
-        if (!springArtifactSpec.isV4() || !LibraryType.spring.equals(springArtifactSpec.getLibraryType()) || bomVersion == null) {
+        if (!springArtifactSpec.isV4()
+            || !LibraryType.spring.equals(springArtifactSpec.getLibraryType())
+            || bomVersion == null
+            || isOverridableGAVersion(bomVersion, artifactVersion)) {
             if (artifactVersion == null) {
                 throw new IllegalStateException("No version found for " + springArtifactSpec.getArtifactId());
             }
@@ -244,6 +248,13 @@ public class SpringReferenceIntellijApplication implements CommandLineRunner {
             return  artifactVersion;
         }
         return bomVersion;
+    }
+
+    private boolean isOverridableGAVersion(VersionSpec bomVersion, VersionSpec artifactVersion) {
+        if (bomVersion == null || artifactVersion == null || !StringUtils.hasText(artifactVersion.getGaVersion())) {
+            return false;
+        }
+        return !bomVersion.getGaVersion().equals(artifactVersion.getGaVersion());
     }
 
     private Map<String, String> buildLinks(SpringArtifactSpec springArtifactSpec, VersionSpec versionSpec) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -486,7 +486,7 @@ spring.cloud.azure.reference:
           version: 4.4.1
     - artifact-id: spring-cloud-azure-starter-jdbc-mysql
       lowest-spring-boot-version: 2.5.0
-      highest-spring-boot-version: 2.7.3
+      highest-spring-boot-version: 3.0.0-RC1
       mappings:
         - lowest-spring-boot-version: 2.5.0
           highest-spring-boot-version: 2.5.14
@@ -502,7 +502,7 @@ spring.cloud.azure.reference:
           version: 6.0.0-beta.3
     - artifact-id: spring-cloud-azure-starter-jdbc-postgresql
       lowest-spring-boot-version: 2.5.0
-      highest-spring-boot-version: 2.7.3
+      highest-spring-boot-version: 3.0.0-RC1
       mappings:
         - lowest-spring-boot-version: 2.5.0
           highest-spring-boot-version: 2.5.14
@@ -524,6 +524,7 @@ spring.cloud.azure.reference:
       ga-version: 2.7.0
     - artifact-id: spring-cloud-azure-starter-data-cosmos
       ga-version: 4.4.1
+      has-preview-version: false
     - artifact-id: spring-cloud-azure-starter-jdbc-mysql
       ga-version: 4.5.0-beta.1
       preview-version: 6.0.0-beta.3


### PR DESCRIPTION
When the version managed by bom is inconsistent with the customized GA version, take the customized one.
MySQL and ProgreSQL should take the `4.5.0-beta.1` as GA version, not `4.4.1`.